### PR TITLE
Better button size for mobile

### DIFF
--- a/packages/helpers/qrcode-modal/src/browser/components/MobileLinkDisplay.tsx
+++ b/packages/helpers/qrcode-modal/src/browser/components/MobileLinkDisplay.tsx
@@ -128,7 +128,7 @@ function MobileLinkDisplay(props: MobileLinkDisplayProps) {
               const selected = page === pageNumber;
               return (
                 <a
-                  style={{ margin: "auto 10px", fontWeight: selected ? "bold" : "normal" }}
+                  style={{ margin: "auto 20px", fontWeight: selected ? "bold" : "normal" }}
                   onClick={() => setPage(pageNumber)}
                 >
                   {pageNumber}


### PR DESCRIPTION
It's hard to navigate between pages because buttons are too close to each other.

before
![image](https://user-images.githubusercontent.com/6696080/131661961-96cd6d60-a774-4ded-b90f-50d7b5c14a19.png)

after
![image](https://user-images.githubusercontent.com/6696080/131661918-381154d9-c431-4c4a-ad73-d168b10748ab.png)
